### PR TITLE
Implement `--exclude` and `--include` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ Usage: monosasi [options]
     -o, --output FILE
         --split
         --target REGEXP
+        --include REGEXP
+        --exclude REGEXP
         --no-color
         --debug
 ```
+
+Note that now `--target` option is deprecated so it will be removed eventually. So consider use equivalent option `--include` instead of.
 
 ## Rulefile example
 

--- a/exe/monosasi
+++ b/exe/monosasi
@@ -36,15 +36,17 @@ def parse_options(argv)
     options[:aws][:credentials][:path] = v
   end
 
-  opt.on('-a', '--apply')         {    options[:mode]    = :apply        }
-  opt.on('-f', '--file FILE')     {|v| options[:file]    = v             }
-  opt.on(''  , '--dry-run')       {    options[:dry_run] = true          }
-  opt.on('-e', '--export')        {    options[:mode]    = :export       }
-  opt.on('-o', '--output FILE')   {|v| options[:output]  = v             }
-  opt.on(''  , '--split')         {    options[:split]   = :true         }
-  opt.on(''  , '--target REGEXP') {|v| options[:target]  = Regexp.new(v) }
-  opt.on(''  , '--no-color')      {    options[:color]   = false         }
-  opt.on(''  , '--debug')         {    options[:debug]   = true          }
+  opt.on('-a', '--apply')          {    options[:mode]    = :apply        }
+  opt.on('-f', '--file FILE')      {|v| options[:file]    = v             }
+  opt.on(''  , '--dry-run')        {    options[:dry_run] = true          }
+  opt.on('-e', '--export')         {    options[:mode]    = :export       }
+  opt.on('-o', '--output FILE')    {|v| options[:output]  = v             }
+  opt.on(''  , '--split')          {    options[:split]   = :true         }
+  opt.on(''  , '--target REGEXP')  {|v| options[:target]  = Regexp.new(v) }
+  opt.on(''  , '--include REGEXP') {|v| options[:include] = Regexp.new(v) }
+  opt.on(''  , '--exclude REGEXP') {|v| options[:exclude] = Regexp.new(v) }
+  opt.on(''  , '--no-color')       {    options[:color]   = false         }
+  opt.on(''  , '--debug')          {    options[:debug]   = true          }
 
   opt.parse!(argv)
 
@@ -68,6 +70,10 @@ def parse_options(argv)
       :http_wire_trace => true,
       :logger => Monosasi::Logger.instance
     )
+  end
+
+  if options[:target]
+    Monosasi::Logger.instance.warn('--target option is deprecated so it will be removed eventually. Consider use --incldue option instead of.')
   end
 
   options

--- a/lib/monosasi/utils/target_matcher.rb
+++ b/lib/monosasi/utils/target_matcher.rb
@@ -1,8 +1,13 @@
 class Monosasi::Utils
   module TargetMatcher
     def target?(name)
-      if @options[:target]
-        @options[:target] =~ name
+      case
+      when @options[:include]
+        @options.fetch(:include) =~ name
+      when @options[:target]
+        @options.fetch(:target) =~ name
+      when @options[:exclude]
+        @options.fetch(:exclude) !~ name
       else
         true
       end


### PR DESCRIPTION
I implemented `--exclude` option. It will be useful when we want to specify target resources as a black list.

Current implementation provides `--target` option, but it's not preferred an opposite form of `--exclude` I think. So I implemented also `--include` option as an equivalent `--target` option.

@winebarrel Could you review this PR? And I'm going to release this gem as version 1.2.0 so I want to access rights to push it to rubygems.org.