### PR TITLE
support network_configuration in ecs_parameters

### DIFF
--- a/monosasi.gemspec
+++ b/monosasi.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '>= 2.5'
+  spec.add_dependency 'aws-sdk', '>= 2.11.118'
   spec.add_dependency 'diffy'
   spec.add_dependency 'hashie'
   spec.add_dependency 'parallel'


### PR DESCRIPTION
update `aws-sdk` to latest version

It has been supported in [This PR](https://github.com/aws/aws-sdk-ruby/commit/43687b4ce5c670ad5491cce52a99994d1cdbc9e0) 